### PR TITLE
FBL-008: Runbook fixes + Phase 2 preparation

### DIFF
--- a/close/MONTH_END_CLOSE_OPERATING_MODEL.md
+++ b/close/MONTH_END_CLOSE_OPERATING_MODEL.md
@@ -41,12 +41,14 @@
 
 ### Exit Criteria
 - All source data complete in Exact Online (sales invoices, purchases, bank)
+- All dagboek entries for the period processed (verwerkt) — 0 te verwerken
 - All exceptions triaged: resolved or deferred with documented justification
 - Finance Lead sign-off on pre-close
 
 ### Required Evidence
-- Sync report showing Zoho Books count = Exact Online count
-- Bank statement import confirmation
+- Sync report: Zoho Books invoice count (Verkoop > Facturen) = Exact Online dagboek 70 count
+- Bank statement import confirmation (last import date per account >= period end date)
+- Verwerken confirmation: screenshot or count showing 0 "te verwerken" entries for the period
 - Exception register status (open/deferred/resolved counts)
 - Pre-close sign-off (name + date)
 
@@ -65,6 +67,7 @@
 ### Entry Criteria
 - Phase 1 completed with sign-off
 - All source data confirmed complete
+- **All dagboek entries for the period processed (verwerkt) in Exact Online** — verify via Financieel > Boekingen > Overzicht: "Aantal te verwerken" = 0 for all dagboeken in the period
 - Journal entry templates available (from `finance-config-catalog/journals/`)
 
 ### Tasks

--- a/close/archive/2026-03/close-package-index.md
+++ b/close/archive/2026-03/close-package-index.md
@@ -1,0 +1,73 @@
+# Close Package Index — March 2026
+
+**Period:** 2026-03
+**Status:** In progress
+
+This index tracks all required close-package artifacts for the March 2026 governed close.
+
+## Required Artifacts
+
+### Phase 1 — Pre-Close Evidence
+
+| # | Artifact | Status | File/Location |
+|---|---|---|---|
+| 1.1 | Sales invoice sync count comparison (Zoho 29 = Exact 29) | Done | Documented in close-checklist-2026-03.md |
+| 1.2 | Exception register status | Done | 0 exceptions (first close) |
+| 1.3 | Bank import confirmation per account | Pending | Finance Lead captures after import completion |
+| 1.4 | Verwerken confirmation (0 te verwerken) | Pending | Finance Lead captures after processing |
+| 1.5 | Pre-close sign-off | Pending | Name + date in close checklist |
+
+### Phase 2 — Controlled Close Evidence
+
+| # | Artifact | Status | File/Location |
+|---|---|---|---|
+| 2.1 | Journal listing period 3 (all dagboeken, verwerkt) | Pending | Export from Exact Online |
+| 2.2 | Depreciation preview + post confirmation | Pending | Screenshot or export from Exact |
+| 2.3 | Salary accrual calculation + journal entry | Pending | Calculation basis + GL entry |
+| 2.4 | Cost accrual entries + estimation basis | Pending | Per category: amount + basis |
+| 2.5 | Controlled close sign-off | Pending | Name + date in close checklist |
+
+### Phase 3 — Review Close Evidence
+
+| # | Artifact | Status | File/Location |
+|---|---|---|---|
+| 3.1 | Balance sheet review notes | Pending | Per-account review notes |
+| 3.2 | P&L analytical review (vs prior period) | Pending | Variance analysis with explanations |
+| 3.3 | VAT reconciliation | Pending | Use templates/reconciliation-template.md |
+| 3.4 | Bank reconciliation | Pending | Use templates/reconciliation-template.md |
+| 3.5 | Debtor balance review | Pending | Aging analysis or balance confirmation |
+| 3.6 | Creditor balance review | Pending | Aging analysis or balance confirmation |
+| 3.7 | Control assessment results | Pending | Use templates/control-assessment-template.md |
+| 3.8 | Review close sign-off | Pending | Name + date in close checklist |
+
+### Phase 4 — Final Close Evidence
+
+| # | Artifact | Status | File/Location |
+|---|---|---|---|
+| 4.1 | Finance Lead approval | Pending | Name + date in close checklist |
+| 4.2 | CFO approval (if required) | Pending | Name + date |
+| 4.3 | Period close confirmation from Exact Online | Pending | Screenshot: period status = "Closed" |
+| 4.4 | Lessons learned | In progress | Documented in close checklist |
+
+## Minimum Substantiation Standard
+
+For this first governed close, the minimum acceptable substantiation per category:
+
+| Category | Minimum evidence | Format |
+|---|---|---|
+| **Sales invoice completeness** | Count comparison Zoho vs Exact | Table in close checklist (done) |
+| **Purchase completeness** | Confirmation all invoices processed | Note after verwerken |
+| **Bank completeness** | Import date confirmation per account | Note with dates |
+| **Journals** | Journal listing for the period | Export or screenshot from Exact |
+| **Depreciation** | Preview output before posting | Screenshot from Exact |
+| **Balance sheet** | Per-account review with notes on material balances | Notes in review section |
+| **P&L** | Comparison to prior period, explain variances > 10% | Notes in review section |
+| **VAT** | GL balance vs BTW-aangifte reconciliation | Completed reconciliation template |
+| **Bank reconciliation** | GL balance vs bank statement balance | Completed reconciliation template |
+| **Controls** | At minimum: CTRL-SI-001 (sync completeness) assessed | Control assessment template |
+
+## Notes
+
+- For the first governed close, the goal is to prove the process works and capture lessons — not to produce audit-grade documentation.
+- Evidence quality will improve with each subsequent close cycle.
+- All artifacts are committed to `close/archive/2026-03/` via PR.

--- a/close/archive/2026-03/phase2-restart-checklist.md
+++ b/close/archive/2026-03/phase2-restart-checklist.md
@@ -1,0 +1,38 @@
+# Phase 2 Restart Checklist — March 2026
+
+**Purpose:** Confirm all prerequisites are met before starting the controlled close for March 2026.
+
+## Prerequisites (all must be true)
+
+| # | Prerequisite | How to verify | Status |
+|---|---|---|---|
+| 1 | All dagboek entries for period 3 processed | Financieel > Boekingen > Overzicht: year 2026, all dagboeken show 0 "Te verwerken" for period 3 | [ ] |
+| 2 | Phase 1 pre-close signed off | Close checklist Phase 1 section has sign-off name + date | [ ] |
+| 3 | Bank import complete through 31-03-2026 | Dashboard: both RABO accounts show "Bijgewerkt t/m" >= 31-03-2026 | [ ] |
+| 4 | Journal templates amounts confirmed | finance-config-catalog/journals/journal-templates.md: expense GL accounts and estimated amounts filled in by Finance Lead | [ ] |
+
+## Phase 2 Tasks with Evidence Requirements
+
+| # | Task | Evidence to capture | Where to save |
+|---|---|---|---|
+| 2.1 | Post recurring journal entries | Journal listing from Exact for period 3, dagboek 90 | close/archive/2026-03/ |
+| 2.2 | Post salary accruals | Journal entry with amounts, GL accounts used, calculation basis | close/archive/2026-03/ |
+| 2.3 | Post cost accruals | Journal entry per accrual category, estimated amount + basis | close/archive/2026-03/ |
+| 2.4 | Reverse prior period accruals | N/A for first close | — |
+| 2.5 | Run fixed asset depreciation | Depreciation preview output (before posting) + posted confirmation | close/archive/2026-03/ |
+| 2.6 | Process asset additions/disposals | Approval record per item (if any) | close/archive/2026-03/ |
+| 2.7 | Manual journals | Each entry with supporting documentation attached | close/archive/2026-03/ |
+| 2.8 | Verify all journals correct | Journal listing for period 3 — all dagboeken, verwerkt entries | close/archive/2026-03/ |
+
+## Phase 2 Exit Criteria
+
+- [ ] All recurring entries posted and verified against templates
+- [ ] Salary accruals posted (or documented as N/A with reason)
+- [ ] Cost accruals posted (or documented as N/A with reason)
+- [ ] Depreciation run completed (preview reviewed, posted)
+- [ ] All manual journals have attached support
+- [ ] Finance Lead sign-off on controlled close
+
+## After Phase 2
+
+Commit all evidence to `close/archive/2026-03/` via PR. Then proceed to Phase 3 (Review Close).

--- a/close/month-end-close-runbook.md
+++ b/close/month-end-close-runbook.md
@@ -20,8 +20,10 @@ Every month-end. Start at business day -5 relative to month-end.
 ### Step 2: Pre-Close
 
 **2.1 Sales Invoice Sync**
-1. Run sync report from finance-automation
-   - *Until automation is live:* manually compare Zoho Books invoice count (Verkoop > Facturen, filter by period) to Exact Online posted sales invoice count (Verkoop > Verkoopfacturen > Overzicht, filter by period). Document both counts.
+1. Compare Zoho Books invoice count to Exact Online
+   - Zoho Books: Verkoop > Facturen, filter by period dates
+   - Exact Online: Financieel > Boekingen > Overzicht, filter dagboek **70 - Verkoopboek**, period. Count = "Aantal te verwerken boekingen" + "Aantal verwerkte boekingen"
+   - *Note:* Sales invoices are entered via dagboek 70 (Verkoopboek), not the Verkoopfacturen module.
 2. Verify counts match between Zoho Books and Exact
 3. Review pending/failed items
 4. Resolve or defer exceptions (document each)
@@ -32,6 +34,8 @@ Every month-end. Start at business day -5 relative to month-end.
 
 **2.3 Bank Processing**
 1. Verify all bank statements imported through month-end
+   - Check each bank account's last import date (dashboard shows "Bijgewerkt t/m")
+   - *Known gap:* secondary bank account (NL74 RABO 3666 7097 88) may lag behind. If import date < period end, trigger manual import via Financieel > Bank en kas > Bankrekeningen > Afschriften > Import.
 2. Review and match unmatched items
 3. Document items that cannot be matched
 
@@ -44,6 +48,26 @@ Every month-end. Start at business day -5 relative to month-end.
 **2.5 Pre-Close Sign-Off**
 1. Review with Finance Lead
 2. Obtain sign-off
+
+### Step 2.6: Process All Entries (Verwerken)
+
+**Before starting the controlled close, all dagboek entries for the period must be processed.**
+
+1. Go to Financieel > Boekingen > Verwerken
+2. Select year and period
+3. Process each dagboek:
+   - 20 — Bank NL16 RABO
+   - 22 — Bank NL74 RABO
+   - 60 — Inkoopboek
+   - 70 — Verkoopboek
+   - 80 — Memoriaal Lonen
+   - 90 — Memoriaal
+   - 94 — Memoriaal uitgestelde omzet en kosten
+   - 95 — Activamutaties
+4. Verify: "Aantal te verwerken boekingen" = 0 for all dagboeken in the period
+5. Document: total entries processed per dagboek
+
+> **Gate:** Do not proceed to Step 3 until all entries show "Verwerkt". Unprocessed entries will not appear in trial balance, reconciliations, or financial reports.
 
 ### Step 3: Controlled Close
 


### PR DESCRIPTION
## Summary
Apply 3 runbook fixes from Phase 1 findings. Prepare Phase 2 restart checklist and close-package index.

## Runbook fixes
1. **Explicit Verwerken step** (Step 2.6) — gate between pre-close and controlled close
2. **Dagboek 70 reference** — sales invoices use Verkoopboek, not Verkoopfacturen module
3. **Bank import lag** — NL74 RABO secondary account documented

## Phase 2 preparation
- `phase2-restart-checklist.md` — 4 prerequisites, 8 tasks with evidence requirements
- `close-package-index.md` — artifact index for all 4 phases + minimum substantiation standard

## References
References #4